### PR TITLE
Catch git errors when run with --dry-run instead of aborting

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -13,6 +13,7 @@ colorama==0.4.1
 coverage==4.5.2
 docopt==0.6.2
 docutils==0.14
+entrypoints==0.3
 flake8==3.5.0
 idna==2.8
 importlib-metadata==0.7
@@ -40,7 +41,7 @@ requests==2.21.0
 schema==0.6.8
 setuptools==40.8.0
 six==1.12.0
-tabulate==0.8.2
+tabulate==0.8.3
 termcolor==1.1.0
 toml==0.10.0
 tqdm==4.28.1


### PR DESCRIPTION
Fix #41 