### PR TITLE
Fix invalid syntax in template

### DIFF
--- a/tbump/init.py
+++ b/tbump/init.py
@@ -28,7 +28,7 @@ def init(working_path: Path, *, current_version: str) -> None:
     template = textwrap.dedent(
         """\
         # Uncomment this if your project is hosted on GitHub:
-        # github_url = https://github.com/<user or organization>/<project>/
+        # github_url = "https://github.com/<user or organization>/<project>/"
 
         [version]
         current = "@current_version@"


### PR DESCRIPTION
`--init` creates a tbum.toml templates that contains invalid quoting when uncommenting the github url section.

```shell
$ tbump init 0.2.3
:: Generating tbump config file
=> ✓ Generated tbump.toml
$ tbump --dry-run 0.2.4
Error: Invalid config: Unexpected character: 'h' at line 2 col 13
```