### PR TITLE
Allow to create the tag but not push it

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+6.3.1 (2021-02-05)
+------------------
+
+* Add a ``--no-tag-push`` option to create the tag but not push it
+
 6.3.0 (2021-02-05)
 ------------------
 

--- a/tbump/git_bumper.py
+++ b/tbump/git_bumper.py
@@ -123,7 +123,7 @@ class GitBumper:
             tag_name = self.get_tag_name(new_version)
             self.check_ref_does_not_exists(tag_name)
 
-        if "push" in self.operations:
+        if "push_commit" in self.operations:
             self.get_current_branch()
             tracking_ref = self.get_tracking_ref()
             self.remote_name, self.remote_branch = tracking_ref.split("/", maxsplit=1)
@@ -145,8 +145,8 @@ class GitBumper:
             self.add_command(
                 res, "tag", "--annotate", "--message", tag_message, tag_name
             )
-        if "push" in self.operations:
+        if "push_commit" in self.operations:
             self.add_command(res, "push", self.remote_name, self.remote_branch)
-            if "tag" in self.operations:
+            if "push_tag" in self.operations:
                 self.add_command(res, "push", self.remote_name, tag_name)
         return res

--- a/tbump/hooks.py
+++ b/tbump/hooks.py
@@ -69,7 +69,7 @@ class HooksRunner:
         return self._get_hooks_for_new_version_by_type(new_version, "before_commit")
 
     def get_after_hooks(self, new_version: str) -> List[Hook]:
-        if "push" in self.operations:
+        if "push_tag" in self.operations or "push_commit" in self.operations:
             return self._get_hooks_for_new_version_by_type(new_version, "after_push")
         else:
             return []

--- a/tbump/main.py
+++ b/tbump/main.py
@@ -35,7 +35,8 @@ Options:
    --dry-run          Only display the changes that would be made.
    --only-patch       Only patches files, skipping any git operations or hook commands.
    --no-tag           Do not create a tag
-   --no-push          DO not push after creating the commit and/or tag
+   --no-push          Do not push after creating the commit and/or tag
+   --no-tag-push      Create a tag, but don't push it
 """
 )
 
@@ -86,13 +87,19 @@ def run(cmd: List[str]) -> None:
     if opt_dict["--non-interactive"]:
         bump_options.interactive = False
 
-    operations = ["patch", "hooks", "commit", "tag", "push"]
+    operations = ["patch", "hooks", "commit", "tag", "push_commit", "push_tag"]
     if opt_dict["--only-patch"]:
         operations = ["patch"]
     if opt_dict["--no-push"]:
-        operations.remove("push")
+        operations.remove("push_commit")
+        operations.remove("push_tag")
+    if opt_dict["--no-tag-push"]:
+        operations.remove("push_tag")
     if opt_dict["--no-tag"]:
         operations.remove("tag")
+        # Also remove push_tag if it's still in the list:
+        if "push_tag" in operations:
+            operations.remove("push_tag")
     bump(bump_options, operations)
 
 
@@ -153,7 +160,7 @@ def bump(options: BumpOptions, operations: List[str]) -> None:
 
     executor.run()
 
-    if config.github_url and "push" in operations:
+    if config.github_url and "push_tag" in operations:
         tag_name = git_bumper.get_tag_name(new_version)
         suggest_creating_github_release(config.github_url, tag_name)
 

--- a/tbump/test/test_git_bumper.py
+++ b/tbump/test/test_git_bumper.py
@@ -13,7 +13,7 @@ def test_git_bumper(test_repo: Path) -> GitBumper:
     config_file = tbump.config.get_config_file(test_repo)
     config = config_file.get_config()
     git_bumper = tbump.git_bumper.GitBumper(
-        test_repo, operations=["commit", "tag", "push"]
+        test_repo, operations=["commit", "tag", "push_commit", "push_tag"]
     )
     git_bumper.set_config(config)
     return git_bumper

--- a/tbump/test/test_main.py
+++ b/tbump/test/test_main.py
@@ -381,3 +381,20 @@ def test_no_tag_no_push(test_repo: Path) -> None:
 
     assert commit_created(test_repo)
     assert not tag_created(test_repo)
+
+
+def test_create_tag_but_do_not_push_it(test_repo: Path) -> None:
+    _, previous_commit = tbump.git.run_git_captured(test_repo, "rev-parse", "HEAD")
+
+    tbump.main.main(
+        [
+            "-C",
+            str(test_repo),
+            "1.2.41-alpha-2",
+            "--non-interactive",
+            "--no-tag-push",
+        ]
+    )
+
+    assert tag_created(test_repo)
+    assert not tag_pushed(test_repo)


### PR DESCRIPTION
This is useful when using `tbump` with PKGBUILD files: the git backend
of aur.archlinux.org does not allow to push tags, but it's still useful
to have them locally.